### PR TITLE
Patch for counter cache override.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
   gem 'nokogiri', '>= 1.6.7.1'
 
   # Needed for compiling the ActionDispatch::Journey parser.
-  gem 'racc', '>=1.4.6', require: false
+  gem 'racc', '>=1.4.16', require: false
 
   # Active Record.
   gem 'sqlite3', '~> 1.3.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,7 +215,7 @@ GEM
       redis-namespace
       simple_uuid
     que (0.14.1)
-    racc (1.4.14)
+    racc (1.5.1)
     rack (2.0.4)
     rack-cache (1.7.1)
       rack (>= 0.4)
@@ -356,7 +356,7 @@ DEPENDENCIES
   qu-redis
   que
   queue_classic!
-  racc (>= 1.4.6)
+  racc (>= 1.4.16)
   rack-cache (~> 1.2)
   rails!
   rake (>= 11.1)

--- a/activerecord/lib/counter_cache_override.rb
+++ b/activerecord/lib/counter_cache_override.rb
@@ -1,0 +1,153 @@
+
+if !ActiveRecord.gem_version.to_s.start_with?("5.0")
+  ActiveSupport::Deprecation.warn("Counter Cache Override is only tested with rails 5.0")
+end
+
+module CounterCacheOverride
+  module GetterAccessors
+    def define_accessors(model, reflection)
+      super
+      define_counter_cache_getter_override(model, reflection)
+    end
+
+    def define_counter_cache_getter_override(model, reflection)
+      cc_getter = reflection.options[:counter_cache_override].to_s
+      model.define_method cc_getter do
+        sql = "select sum(increment) as sum from #{model.table_name}_#{cc_getter}s where parent_id = :id"
+        sum = ActiveRecord::Base.connection.exec_query(ActiveRecord::Base.send(:sanitize_sql_array,[sql, id: id]))[0]["sum"].to_i
+        self.read_attribute(cc_getter).to_i + sum unless read_attribute(cc_getter).nil? && sum == 0
+      end
+    end
+  end
+end
+ActiveRecord::Associations::Builder::Association.singleton_class.prepend CounterCacheOverride::GetterAccessors
+
+module CounterCacheOverride
+  module CounterCache
+    extend ActiveSupport::Concern
+    module ClassMethods
+      def reset_counters(id, *counters)
+        object = find(id)
+        counters.each do |counter_association|
+          has_many_association = _reflect_on_association(counter_association)
+          unless has_many_association
+            has_many = reflect_on_all_associations(:has_many)
+            has_many_association = has_many.find { |association| association.counter_cache_column && association.counter_cache_column.to_sym == counter_association.to_sym }
+            counter_association = has_many_association.plural_name if has_many_association
+          end
+          raise ArgumentError, "'#{self.name}' has no association called '#{counter_association}'" unless has_many_association
+
+          if has_many_association.is_a? ActiveRecord::Reflection::ThroughReflection
+            has_many_association = has_many_association.through_reflection
+          end
+
+          foreign_key  = has_many_association.foreign_key.to_s
+          child_class  = has_many_association.klass
+          reflection   = child_class._reflections.values.find { |e| e.belongs_to? && e.foreign_key.to_s == foreign_key && e.options[:counter_cache].present? }
+          counter_name = reflection.counter_cache_column
+
+          unscoped.where(primary_key => object.id).update_all(
+            counter_name => object.send(counter_association).count(:all)
+          )
+          counter_table_name = "#{table_name}_#{counter_name}s"
+          Array.wrap(id).each do |idx|
+            sql = "delete from  #{counter_table_name} where parent_id=:parent_id"
+            connection.exec_query(sanitize_sql_array([sql, parent_id: idx]))
+          end
+        end
+        return true
+      end
+
+      def update_counters(id, counters)
+        super(id, counters_with_default(counters)) unless counters_with_default(counters).empty?
+
+        counters_using_override(counters).map do |counter_name, value|
+          counter_table_name = "#{table_name}_#{counter_name}s"
+          operator = value < 0 ? '-' : '+'
+          Array.wrap(id).each do |idx|
+            #sql = "insert into :counter_table_name(parent_id, increment) values(:idx, :increment_by)"
+            sql = "insert into #{counter_table_name}(parent_id, increment) values(:idx, :increment_by)"
+            # ISSUE: This next line is a bit of a hack because of how in memory decrements work
+            value = value == 0 ? -1 : value
+            connection.exec_query(sanitize_sql_array([sql, idx: idx, increment_by: value]))
+          end
+        end
+      end
+
+      private
+      def counter_overrides
+        # TODO memoize
+        reflections.values.map{ |ref| ref.options[:counter_cache_override] }.compact.map(&:to_s)
+      end
+
+      def counters_using_override(counters)
+        counters.select { |key,_|  counter_overrides.include?(key) }
+      end
+
+      def counters_with_default(counters)
+        counters.reject { |key,_|  counter_overrides.include?(key) }
+      end
+    end
+  end
+end
+ActiveRecord::Base.include CounterCacheOverride::CounterCache
+
+module CounterCacheOverride
+  module HasManyCounts
+
+    private
+    def count_records
+      count = if reflection.has_cached_counter? &&
+        reflection.options[:counter_cache_override].to_s == reflection.counter_cache_column.to_s
+        owner.send(reflection.counter_cache_column.to_sym) || 0
+      elsif reflection.has_cached_counter?
+        owner._read_attribute reflection.counter_cache_column
+      else
+        scope.count
+      end
+
+      # If there's nothing in the database and @target has no new records
+      # we are certain the current target is an empty array. This is a
+      # documented side-effect of the method that may avoid an extra SELECT.
+      @target ||= [] and loaded! if count == 0
+
+      [association_scope.limit_value, count].compact.min
+    end
+
+    def update_counter_in_memory(difference, reflection = reflection())
+      if reflection.counter_must_be_updated_by_has_many?
+        counter = reflection.counter_cache_column
+        return if counter.to_s == reflection.options[:counter_cache_override].to_s
+        owner.increment(counter, difference)
+        owner.send(:clear_attribute_change, counter) # eww
+      end
+    end
+  end
+end
+ActiveRecord::Associations::HasManyAssociation.prepend CounterCacheOverride::HasManyCounts
+
+module CounterCacheOverride
+  module ValidOptions
+    def valid_options(options)
+      super + [:counter_cache_override]
+    end
+  end
+end
+ActiveRecord::Associations::Builder::HasMany.singleton_class.prepend CounterCacheOverride::ValidOptions
+
+module ActiveRecord
+  module Persistence
+    def increment!(attribute, by = 1)
+      if _reflections.values.map{ |ref| ref.options[:counter_cache_override] }.compact.map(&:to_s).include?(attribute.to_s)
+        self.class.update_counters(id, attribute => by)
+      else
+        increment(attribute, by)
+        change = public_send(attribute) - (attribute_was(attribute.to_s) || 0)
+        self.class.update_counters(id, attribute => change)
+        clear_attribute_change(attribute) # eww
+      end
+      self
+    end
+  end
+end
+

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -29,6 +29,11 @@ class CounterCacheTest < ActiveRecord::TestCase
 
   setup do
     @topic = Topic.find(1)
+    @c = Car.find(1)
+  end
+
+  test "hello world" do
+    assert_equal 0, @c.engines_count
   end
 
   test "increment counter" do
@@ -63,53 +68,53 @@ class CounterCacheTest < ActiveRecord::TestCase
     end
   end
 
-  test 'reset multiple counters' do
-    Topic.update_counters @topic.id, replies_count: 1, unique_replies_count: 1
-    assert_difference ['@topic.reload.replies_count', '@topic.reload.unique_replies_count'], -1 do
-      Topic.reset_counters(@topic.id, :replies, :unique_replies)
-    end
-  end
+   test 'reset multiple counters' do
+     Topic.update_counters @topic.id, replies_count: 1, unique_replies_count: 1
+     assert_difference ['@topic.reload.replies_count', '@topic.reload.unique_replies_count'], -1 do
+       Topic.reset_counters(@topic.id, :replies, :unique_replies)
+     end
+   end
 
-  test "reset counters with string argument" do
-    Topic.increment_counter('replies_count', @topic.id)
+   test "reset counters with string argument" do
+     Topic.increment_counter('replies_count', @topic.id)
 
-    assert_difference '@topic.reload.replies_count', -1 do
-      Topic.reset_counters(@topic.id, 'replies')
-    end
-  end
+     assert_difference '@topic.reload.replies_count', -1 do
+       Topic.reset_counters(@topic.id, 'replies')
+     end
+   end
 
-  test "reset counters with modularized and camelized classnames" do
-    special = SpecialTopic.create!(:title => 'Special')
-    SpecialTopic.increment_counter(:replies_count, special.id)
+   test "reset counters with modularized and camelized classnames" do
+     special = SpecialTopic.create!(:title => 'Special')
+     SpecialTopic.increment_counter(:replies_count, special.id)
 
-    assert_difference 'special.reload.replies_count', -1 do
-      SpecialTopic.reset_counters(special.id, :special_replies)
-    end
-  end
+     assert_difference 'special.reload.replies_count', -1 do
+       SpecialTopic.reset_counters(special.id, :special_replies)
+     end
+   end
 
-  test "reset counter with belongs_to which has class_name" do
-    car = cars(:honda)
-    assert_nothing_raised do
-      Car.reset_counters(car.id, :engines)
-    end
-    assert_nothing_raised do
-      Car.reset_counters(car.id, :wheels)
-    end
-  end
+   test "reset counter with belongs_to which has class_name" do
+     car = cars(:honda)
+     assert_nothing_raised do
+       Car.reset_counters(car.id, :engines)
+     end
+     assert_nothing_raised do
+       Car.reset_counters(car.id, :wheels)
+     end
+   end
 
-  test "reset the right counter if two have the same class_name" do
-    david = dog_lovers(:david)
+   test "reset the right counter if two have the same class_name" do
+     david = dog_lovers(:david)
 
     DogLover.increment_counter(:bred_dogs_count, david.id)
-    DogLover.increment_counter(:trained_dogs_count, david.id)
+     DogLover.increment_counter(:trained_dogs_count, david.id)
 
-    assert_difference 'david.reload.bred_dogs_count', -1 do
-      DogLover.reset_counters(david.id, :bred_dogs)
-    end
-    assert_difference 'david.reload.trained_dogs_count', -1 do
-      DogLover.reset_counters(david.id, :trained_dogs)
-    end
-  end
+     assert_difference 'david.reload.bred_dogs_count', -1 do
+       DogLover.reset_counters(david.id, :bred_dogs)
+     end
+     assert_difference 'david.reload.trained_dogs_count', -1 do
+       DogLover.reset_counters(david.id, :trained_dogs)
+     end
+   end
 
   test "update counter with initial null value" do
     category = categories(:general)
@@ -120,25 +125,25 @@ class CounterCacheTest < ActiveRecord::TestCase
     assert_equal 2, category.reload.categorizations_count
   end
 
-  test "update counter for decrement" do
-    assert_difference '@topic.reload.replies_count', -3 do
-      Topic.update_counters(@topic.id, :replies_count => -3)
-    end
-  end
+   test "update counter for decrement" do
+     assert_difference '@topic.reload.replies_count', -3 do
+       Topic.update_counters(@topic.id, :replies_count => -3)
+     end
+   end
 
-  test "update counters of multiple records" do
-    t1, t2 = topics(:first, :second)
+   test "update counters of multiple records" do
+     t1, t2 = topics(:first, :second)
 
-    assert_difference ['t1.reload.replies_count', 't2.reload.replies_count'], 2 do
-      Topic.update_counters([t1.id, t2.id], :replies_count => 2)
-    end
-  end
+     assert_difference ['t1.reload.replies_count', 't2.reload.replies_count'], 2 do
+       Topic.update_counters([t1.id, t2.id], :replies_count => 2)
+     end
+   end
 
-  test 'update multiple counters' do
-    assert_difference ['@topic.reload.replies_count', '@topic.reload.unique_replies_count'], 2 do
-      Topic.update_counters @topic.id, replies_count: 2, unique_replies_count: 2
-    end
-  end
+   test 'update multiple counters' do
+     assert_difference ['@topic.reload.replies_count', '@topic.reload.unique_replies_count'], 2 do
+       Topic.update_counters @topic.id, replies_count: 2, unique_replies_count: 2
+     end
+   end
 
   test "update other counters on parent destroy" do
     david, joanna = dog_lovers(:david, :joanna)
@@ -161,17 +166,18 @@ class CounterCacheTest < ActiveRecord::TestCase
     Subscriber.reset_counters(subscriber.id, 'books')
     Subscriber.increment_counter('books_count', subscriber.id)
 
+    # assert_equal subcriber.books_count, 1
     assert_difference 'subscriber.reload.books_count', -1 do
       Subscriber.reset_counters(subscriber.id, 'books')
     end
   end
 
-  test "the passed symbol needs to be an association name or counter name" do
-    e = assert_raises(ArgumentError) do
-      Topic.reset_counters(@topic.id, :undefined_count)
-    end
-    assert_equal "'Topic' has no association called 'undefined_count'", e.message
-  end
+   test "the passed symbol needs to be an association name or counter name" do
+     e = assert_raises(ArgumentError) do
+       Topic.reset_counters(@topic.id, :undefined_count)
+     end
+     assert_equal "'Topic' has no association called 'undefined_count'", e.message
+   end
 
   test "reset counter works with select declared on association" do
     special = SpecialTopic.create!(:title => 'Special')

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -1,10 +1,12 @@
 require 'config'
+require 'byebug'
 
 require 'active_support/testing/autorun'
 require 'active_support/testing/method_call_assertions'
 require 'stringio'
 
 require 'active_record'
+require 'counter_cache_override'
 require 'cases/test_case'
 require 'active_support/dependencies'
 require 'active_support/logger'
@@ -12,6 +14,7 @@ require 'active_support/core_ext/string/strip'
 
 require 'support/config'
 require 'support/connection'
+# byebug
 
 # TODO: Move all these random hacks into the ARTest namespace and into the support/ dir
 

--- a/activerecord/test/models/aircraft.rb
+++ b/activerecord/test/models/aircraft.rb
@@ -1,5 +1,5 @@
 class Aircraft < ActiveRecord::Base
   self.pluralize_table_names = false
   has_many :engines, :foreign_key => "car_id"
-  has_many :wheels, as: :wheelable
+  has_many :wheels, as: :wheelable, counter_cache_override: :wheels_count
 end

--- a/activerecord/test/models/car.rb
+++ b/activerecord/test/models/car.rb
@@ -9,8 +9,8 @@ class Car < ActiveRecord::Base
   has_one :bulb
 
   has_many :tyres
-  has_many :engines, :dependent => :destroy, inverse_of: :my_car
-  has_many :wheels, :as => :wheelable, :dependent => :destroy
+  has_many :engines, :dependent => :destroy, inverse_of: :my_car, counter_cache_override: :engines_count
+  has_many :wheels, :as => :wheelable, :dependent => :destroy, counter_cache_override: :wheels_count
 
   has_many :price_estimates, :as => :estimate_of
 

--- a/activerecord/test/models/category.rb
+++ b/activerecord/test/models/category.rb
@@ -21,7 +21,7 @@ class Category < ActiveRecord::Base
     'a category...'
   end
 
-  has_many :categorizations
+  has_many :categorizations, counter_cache_override: :categorizations_count
   has_many :special_categorizations
   has_many :post_comments, :through => :posts, :source => :comments
 

--- a/activerecord/test/models/dog_lover.rb
+++ b/activerecord/test/models/dog_lover.rb
@@ -1,5 +1,5 @@
 class DogLover < ActiveRecord::Base
-  has_many :trained_dogs, class_name: "Dog", foreign_key: :trainer_id, dependent: :destroy
-  has_many :bred_dogs, class_name: "Dog", foreign_key: :breeder_id
-  has_many :dogs
+  has_many :trained_dogs, class_name: "Dog", foreign_key: :trainer_id, dependent: :destroy, counter_cache_override: :trained_dogs_count
+  has_many :bred_dogs, class_name: "Dog", foreign_key: :breeder_id, counter_cache_override: :bred_dogs_count
+  has_many :dogs, counter_cache_override: :dogs_count
 end

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -10,7 +10,7 @@ class Person < ActiveRecord::Base
 
   has_many :friendships, foreign_key: 'friend_id'
   # friends_too exists to test a bug, and probably shouldn't be used elsewhere
-  has_many :friends_too, foreign_key: 'friend_id', class_name: 'Friendship'
+  has_many :friends_too, foreign_key: 'friend_id', class_name: 'Friendship', counter_cache_override: :friends_too_count
   has_many :followers, through: :friendships
 
   has_many :references

--- a/activerecord/test/models/subscriber.rb
+++ b/activerecord/test/models/subscriber.rb
@@ -1,7 +1,7 @@
 class Subscriber < ActiveRecord::Base
   self.primary_key = 'nick'
   has_many :subscriptions
-  has_many :books, :through => :subscriptions
+  has_many :books, :through => :subscriptions, counter_cache_override: :books_count
 end
 
 class SpecialSubscriber < Subscriber

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -32,10 +32,10 @@ class Topic < ActiveRecord::Base
     end
   end
 
-  has_many :replies, dependent: :destroy, foreign_key: "parent_id", autosave: true
+  has_many :replies, dependent: :destroy, foreign_key: "parent_id", autosave: true, counter_cache_override: :replies_count
   has_many :approved_replies, -> { approved }, class_name: 'Reply', foreign_key: "parent_id", counter_cache: 'replies_count'
 
-  has_many :unique_replies, :dependent => :destroy, :foreign_key => "parent_id"
+  has_many :unique_replies, :dependent => :destroy, :foreign_key => "parent_id", counter_cache_override: :unique_replies_count
   has_many :silly_unique_replies, :dependent => :destroy, :foreign_key => "parent_id"
 
   serialize :content

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 ActiveRecord::Schema.define do
   # ------------------------------------------------------------------- #
   #                                                                     #
@@ -31,6 +32,11 @@ ActiveRecord::Schema.define do
   create_table :aircraft, force: true do |t|
     t.string :name
     t.integer :wheels_count, default: 0, null: false
+  end
+
+  create_table :aircraft_wheels_counts, force: true do |t|
+    t.integer :parent_id
+    t.integer :increment
   end
 
   create_table :articles, force: true do |t|
@@ -125,6 +131,22 @@ ActiveRecord::Schema.define do
     t.timestamps null: false
   end
 
+  create_table :cars_engines_counts, force: true do |t|
+    t.integer :parent_id
+    t.integer :increment
+  end
+
+  create_table :cars_wheels_counts, force: true do |t|
+    t.integer :parent_id
+    t.integer :increment
+  end
+
+  # create_table :cars_lock_versions, force: true do |t|
+  #   t.integer :parent_id
+  #   t.integer :increment
+  # end
+
+
   create_table :carriers, force: true
 
   create_table :categories, force: true do |t|
@@ -144,6 +166,11 @@ ActiveRecord::Schema.define do
     t.column :post_id, :integer
     t.column :author_id, :integer
     t.column :special, :boolean
+  end
+
+  create_table :categories_categorizations_counts, force: true do |t|
+    t.integer :parent_id
+    t.integer :increment
   end
 
   create_table :citations, force: true do |t|
@@ -282,6 +309,21 @@ ActiveRecord::Schema.define do
     t.integer :trained_dogs_count, default: 0
     t.integer :bred_dogs_count, default: 0
     t.integer :dogs_count, default: 0
+  end
+
+  create_table :dog_lovers_dogs_counts, force: true do |t|
+    t.integer :parent_id
+    t.integer :increment
+  end
+
+  create_table :dog_lovers_bred_dogs_counts, force: true do |t|
+    t.integer :parent_id
+    t.integer :increment
+  end
+
+  create_table :dog_lovers_trained_dogs_counts, force: true do |t|
+    t.integer :parent_id
+    t.integer :increment
   end
 
   create_table :dogs, force: true do |t|
@@ -609,6 +651,11 @@ ActiveRecord::Schema.define do
     t.timestamps null: false
   end
 
+  create_table :people_friends_too_counts, force: true do |t|
+    t.integer :parent_id
+    t.integer :increment
+  end
+
   create_table :peoples_treasures, id: false, force: true do |t|
     t.column :rich_person_id, :integer
     t.column :treasure_id, :integer
@@ -799,6 +846,11 @@ ActiveRecord::Schema.define do
     t.index :nick, unique: true
   end
 
+  create_table :subscribers_books_counts, force: true do |t|
+    t.string :parent_id
+    t.integer :increment
+  end
+
   create_table :subscriptions, force: true do |t|
     t.string :subscriber_id
     t.integer :book_id
@@ -849,6 +901,37 @@ ActiveRecord::Schema.define do
     t.string   :parent_title
     t.string   :type
     t.string   :group
+    if subsecond_precision_supported?
+      t.timestamps null: true, precision: 6
+    else
+      t.timestamps null: true
+    end
+  end
+
+  create_table :topics_replies_counts, force: true do |t|
+    t.integer :parent_id
+    t.integer :increment
+    if subsecond_precision_supported?
+      t.timestamps null: true, precision: 6
+    else
+      t.timestamps null: true
+    end
+  end
+
+  create_table :topics_unique_replies_counts, force: true do |t|
+    t.integer :parent_id
+    t.integer :increment
+    if subsecond_precision_supported?
+      t.timestamps null: true, precision: 6
+    else
+      t.timestamps null: true
+    end
+  end
+
+
+  create_table :topics_replies_counts, force: true do |t|
+    t.integer :parent_id
+    t.integer :increment
     if subsecond_precision_supported?
       t.timestamps null: true, precision: 6
     else


### PR DESCRIPTION
## Description

Write locks on the table rows where rails counter caches are used causes problems in our environment.

## Solution

Instead of updating the counter cache on the parent row, this change creates a new row in a counter cache table and updates the counter cache getter on the parent row to sum the values in the new table plus the value in the counter cache column.

The patch is in `activerecord/lib/counter_cache_override.rb`. The additional changes in this branch are to update tests with the new table.

The following would be required to enable this functionality for a given counter cache otherwise it uses the default counter_cache functionality.

```
create_table :cars_engines_counts, force: true do |t|
    t.integer :parent_id
    t.integer :increment
  end
```
and then in the car model add the `counter_cache_override` option

```
 has_many :engines, :dependent => :destroy, inverse_of: :my_car, counter_cache_override: :engines_count
```
 
The assumption is that a job would be created in our rails app to periodically delete rows from the counter cache tables and update the row counter cache column. 

If you want to see this PR inline in rails code look at this commit - https://github.com/Kajabi/rails/commit/2ae3d40afaabf0b6a05e258bc9813c6d984c2991
